### PR TITLE
Make [[PreventExtensions]] return false

### DIFF
--- a/Location.md
+++ b/Location.md
@@ -36,7 +36,7 @@ See HTML.
 
 ## [[PreventExtensions]\] ( )
 
-1. Throw a TypeError exception.
+1. Return false.
 
 ## [[GetOwnProperty]\] (_P_)
 


### PR DESCRIPTION
This only affects Reflect.preventExtensions() and would match
https://github.com/domenic/window-proxy-spec better. It seems slightly
saner.
